### PR TITLE
chore: add .github/release.yml for automatic release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+# .github/release.yml
+# GitHub リリースノート自動作成のカスタマイズ設定
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+        - semver-major
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+        - semver-minor
+    - title: Bug Fixes
+      labels:
+        - bug
+        - bugfix
+        - semver-patch
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
GitHubのリリースノート自動作成をカスタマイズするため、\.github/release.yml\ を追加しました。

- PRラベルによるカテゴリ分け（Breaking Changes, Features, Bug Fixes, Documentation, Dependencies, Other Changes）
- DependabotのPRを除外
- \ignore-for-release\ ラベルでリリースノートから除外可能

Made with [Cursor](https://cursor.com)