### PR TITLE
feat: 2026イベントページの実装と情報更新

### DIFF
--- a/src/components/2026/AboutSection2026.tsx
+++ b/src/components/2026/AboutSection2026.tsx
@@ -16,6 +16,9 @@ export default function AboutSection2026() {
 
           <div className="mt-10 grid gap-10 lg:grid-cols-2 lg:items-center">
             <div className="section-2026__notice space-y-6 text-base leading-relaxed md:text-lg">
+              <p className="inline-flex w-fit items-center rounded-sm border border-[var(--2026-rule)] bg-[var(--2026-surface)] px-3 py-1 text-sm font-semibold md:text-base">
+                開催日：{SITE_2026.hero.eventDate}
+              </p>
               {SITE_2026.about.paragraphs.map((p, i) => (
                 <p key={i}>{p}</p>
               ))}


### PR DESCRIPTION
## Summary
- 2026年向けページの基本レイアウトを追加し、メタ情報を2026向けに更新
- Hero/Aboutセクションに日程・開催情報を反映
- ルートレイアウトとの整合を取り、2026導線を有効化

## Test plan
- [ ] `npm run dev` で `/2026` が表示できることを確認
- [ ] 2026ページのタイトル/説明文/日程表示が意図どおりであることを確認
- [ ] 既存の `/2025` ページに表示崩れや回帰がないことを確認

Made with [Cursor](https://cursor.com)