### PR TITLE
fix: ヒーロースライドショーの画像プリロードとクロスフェードを改善

### DIFF
--- a/src/components/2026/HeroSlideshow2026.tsx
+++ b/src/components/2026/HeroSlideshow2026.tsx
@@ -1,51 +1,183 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const TRANSITION_MS = 500;
 
 type Props = {
   images: readonly string[];
   intervalMs: number;
 };
 
+function preloadImage(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const img = new window.Image();
+    img.onload = () => resolve();
+    img.onerror = () => reject(new Error(`Failed to preload: ${src}`));
+    img.src = src;
+  });
+}
+
 export default function HeroSlideshow2026({ images, intervalMs }: Props) {
-  const [idx, setIdx] = useState(0);
+  const [activeLayer, setActiveLayer] = useState<0 | 1>(0);
+  const [layerIndices, setLayerIndices] = useState<[number, number]>([0, 1]);
+  const [isReady, setIsReady] = useState(false);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  const imagesRef = useRef(images);
+  imagesRef.current = images;
+
+  const stateRef = useRef({
+    activeLayer: 0 as 0 | 1,
+    isTransitioning: false,
+  });
+  stateRef.current.activeLayer = activeLayer;
+  stateRef.current.isTransitioning = isTransitioning;
+
+  const transitionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   useEffect(() => {
-    images.forEach((src) => {
-      const img = new window.Image();
-      img.src = src;
-    });
+    if (images.length === 0) return;
+
+    let cancelled = false;
+    setIsReady(false);
+    setActiveLayer(0);
+    setLayerIndices([0, Math.min(1, images.length - 1)]);
+    setIsTransitioning(false);
+
+    void (async () => {
+      if (images.length === 1) {
+        try {
+          await preloadImage(images[0]!);
+        } catch {
+          /* continue */
+        }
+        if (!cancelled) setIsReady(true);
+        return;
+      }
+
+      images.forEach((src) => {
+        void preloadImage(src).catch(() => {});
+      });
+
+      try {
+        await Promise.all([
+          preloadImage(images[0]!),
+          preloadImage(images[1]!),
+        ]);
+      } catch {
+        /* continue */
+      }
+
+      if (!cancelled) setIsReady(true);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [images]);
 
+  const advanceSlide = useCallback(() => {
+    const imgs = imagesRef.current;
+    if (imgs.length <= 1) return;
+
+    const { activeLayer: front, isTransitioning: transitioning } =
+      stateRef.current;
+    if (transitioning) return;
+
+    const back = (1 - front) as 0 | 1;
+
+    setLayerIndices((prev) => {
+      const currentIndex = prev[front];
+      const nextIndex = (currentIndex + 1) % imgs.length;
+      const next = [...prev] as [number, number];
+      next[back] = nextIndex;
+      return next;
+    });
+    setIsTransitioning(true);
+
+    transitionTimeoutRef.current = setTimeout(() => {
+      setLayerIndices((prev) => {
+        const currentIndex = prev[front];
+        const nextIndex = (currentIndex + 1) % imgs.length;
+        const hidden = front;
+        const preloadIndex = (nextIndex + 1) % imgs.length;
+        const next = [...prev] as [number, number];
+        next[hidden] = preloadIndex;
+        const preloadSrc = imgs[preloadIndex];
+        if (preloadSrc) {
+          void preloadImage(preloadSrc).catch(() => {});
+        }
+        return next;
+      });
+      setActiveLayer(back);
+      setIsTransitioning(false);
+    }, TRANSITION_MS);
+  }, []);
+
   useEffect(() => {
-    if (images.length <= 1) return;
-    const t = window.setInterval(() => {
-      setIdx((i) => (i + 1) % images.length);
-    }, intervalMs);
+    if (!isReady || images.length <= 1) return;
+
+    const t = window.setInterval(advanceSlide, intervalMs);
     return () => window.clearInterval(t);
-  }, [images.length, intervalMs]);
+  }, [advanceSlide, images.length, intervalMs, isReady]);
+
+  useEffect(() => {
+    return () => {
+      if (transitionTimeoutRef.current) {
+        clearTimeout(transitionTimeoutRef.current);
+      }
+    };
+  }, []);
 
   if (images.length === 0) return null;
 
-  const src = images[idx] ?? images[0];
+  const backLayer = (1 - activeLayer) as 0 | 1;
 
   return (
     <div
-      className="absolute inset-0 w-full h-full"
+      className="absolute inset-0 h-full w-full"
       style={{ zIndex: 0, pointerEvents: "none" }}
     >
-      <Image
-        key={src}
-        src={src}
-        alt=""
-        fill
-        priority={idx === 0}
-        sizes="100vw"
-        className="object-cover transition-opacity duration-[600ms] ease-in-out"
-        style={{ pointerEvents: "none" }}
-        draggable={false}
-      />
+      {([0, 1] as const).map((layer) => {
+        const index = layerIndices[layer] ?? 0;
+        const src = images[index] ?? images[0]!;
+        const targetOpacity = isTransitioning
+          ? layer === backLayer
+            ? 1
+            : 0
+          : layer === activeLayer
+            ? 1
+            : 0;
+        const zIndex =
+          isTransitioning && layer === backLayer
+            ? 2
+            : !isTransitioning && layer === activeLayer
+              ? 2
+              : 1;
+
+        return (
+          <Image
+            key={layer}
+            src={src}
+            alt=""
+            fill
+            priority={layer === 0 && index === 0}
+            sizes="100vw"
+            unoptimized
+            className="object-cover transition-opacity duration-500 ease-in-out"
+            style={{
+              opacity: targetOpacity,
+              zIndex,
+              pointerEvents: "none",
+            }}
+            draggable={false}
+          />
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- CDN直URLと`next/image`表示URLの不一致を`unoptimized`で解消し、プリロードがブラウザキャッシュに効くようにした
- 2レイヤー常時マウント + opacityクロスフェードで切り替え時のちらつきを防止
- 初回2枚の先読み完了後にスライド開始、切り替え後に次々枚をバックグラウンド先読み

## Test plan

- [ ] `npm run dev` で `/2026` を開き、4秒ごとの切り替えが空白なしでフェードすること
- [ ] DevTools Network (Img) で、切り替え時に新規リクエストが発生しないこと
- [ ] 初回訪問（sessionStorageクリア後）でも最初の切り替えがスムーズなこと

Made with [Cursor](https://cursor.com)